### PR TITLE
Fix: ann routes in docs

### DIFF
--- a/pages/rest-api/News/animenewsnetwork/fetch-news-feeds.mdx
+++ b/pages/rest-api/News/animenewsnetwork/fetch-news-feeds.mdx
@@ -11,7 +11,7 @@ Technical details regarding the usage of the fetch news feeds function for the A
 ## Route Schema (URL)
 
 ```
-https://api.consumet.org/news/ANN/recent-feeds
+https://api.consumet.org/news/ann/recent-feeds
 ```
 
 ## Query Parameters
@@ -29,7 +29,7 @@ https://api.consumet.org/news/ANN/recent-feeds
         import axios from "axios";
 
         // Example request using no paramters, which fetches all recent news.
-        const url = "https://api.consumet.org/news/ANN/recent-feeds";
+        const url = "https://api.consumet.org/news/ann/recent-feeds";
         const data = async () => {
             try {
                 const { data } = await axios.get(url);
@@ -50,7 +50,7 @@ https://api.consumet.org/news/ANN/recent-feeds
         import requests
 
         # Example request using no paramters, which fetches all recent news.
-        url = "https://api.consumet.org/news/ANN/recent-feeds"
+        url = "https://api.consumet.org/news/ann/recent-feeds"
         response = requests.get(url)
         data = response.json()
 

--- a/pages/rest-api/News/animenewsnetwork/fetch-news-info.mdx
+++ b/pages/rest-api/News/animenewsnetwork/fetch-news-info.mdx
@@ -11,7 +11,7 @@ Technical details regarding the usage of the fetch news info function for the AN
 ## Route Schema (URL)
 
 ```
-https://api.consumet.org/news/ANN/info/:id
+https://api.consumet.org/news/ann/info
 ```
 
 ## Query Parameters
@@ -29,7 +29,7 @@ https://api.consumet.org/news/ANN/info/:id
         import axios from "axios";
 
         // An example news story about the Kindaichi Case Files ending.
-        const url = "https://api.consumet.org/news/ANN/info/2023-01-10/the-kindaichi-case-files-30th-anniversary-manga-ends-in-4-chapters/.193671";
+        const url = "https://api.consumet.org/news/ann/info?id=2023-04-26/kibo-no-chikara-~otona-precure-23~-anime-teaser-narrated-by-nozomi-yuko-sanpei/.197525";
         const data = async () => {
             try {
                 const { data } = await axios.get(url);
@@ -50,7 +50,7 @@ https://api.consumet.org/news/ANN/info/:id
         import requests
 
         # An example news story about the Kindaichi Case Files ending.
-        url = "https://api.consumet.org/news/ANN/info/2023-01-10/the-kindaichi-case-files-30th-anniversary-manga-ends-in-4-chapters/.193671"
+        url = "https://api.consumet.org/news/ann/info?id=2023-04-26/kibo-no-chikara-~otona-precure-23~-anime-teaser-narrated-by-nozomi-yuko-sanpei/.197525"
         response = requests.get(url)
         data = response.json()
 


### PR DESCRIPTION
Anime news network routes were not matching to the actual routes which returned `{"message":"","error":"page not found"}`

This fixes #7 and consumet/consumet.ts#335