### PR TITLE
[Zoro] Fixed Anime Episode Streaming Links, Route Schema (URL)

### DIFF
--- a/pages/rest-api/Anime/zoro/get-anime-episode-streaming-links.mdx
+++ b/pages/rest-api/Anime/zoro/get-anime-episode-streaming-links.mdx
@@ -14,7 +14,7 @@ key is changed, while our bot is updating the key.
 ## Route Schema (URL)
 
 ```
-https://api.consumet.org/anime/zoro/watch/{episodeId}?server={serverName}
+https://api.consumet.org/anime/zoro/watch/episodeId={episodeId}?server={serverName}
 ```
 
 ## Query Parameters


### PR DESCRIPTION
it wasnt working before,but with adding "episodeId=" before {episodeId} fixes the thing, and makes the docs much easy.